### PR TITLE
Fix memory leak occuring with thread pool resize on Linux with pthreads

### DIFF
--- a/boost/threadpool/detail/pool_core.hpp
+++ b/boost/threadpool/detail/pool_core.hpp
@@ -299,23 +299,23 @@ namespace boost { namespace threadpool { namespace detail
     {
       pool_type* self = const_cast<pool_type*>(this);
       {
-          //Lock should be local to prevent dead lock of all the worker threads
-          recursive_mutex::scoped_lock lock(self->m_monitor);
- 
-          self->m_terminate_all_workers = true;
- 
-          self->m_destruct_barrier.reset( new barrier( m_target_worker_count + 1 ) );  
-          m_target_worker_count = 0;
-          self->m_task_or_terminate_workers_event.notify_all();
+        //Lock should be local to prevent dead lock of all the worker threads
+        recursive_mutex::scoped_lock lock(self->m_monitor);
+
+        self->m_terminate_all_workers = true;
+
+        self->m_destruct_barrier.reset(new barrier(m_target_worker_count + 1));
+        m_target_worker_count = 0;
+        self->m_task_or_terminate_workers_event.notify_all();
       }
- 
-       if(wait)
-       {
-          //Wait for termination of all the workers
-          self->m_destruct_barrier->wait();
- 
-         for(typename std::vector<shared_ptr<worker_type> >::iterator it = self->m_terminated_workers.begin();
-           it != self->m_terminated_workers.end();
+
+      if(wait)
+      {
+        //Wait for termination of all the workers
+        self->m_destruct_barrier->wait();
+
+        for(typename std::vector<shared_ptr<worker_type> >::iterator it = self->m_terminated_workers.begin();
+        it != self->m_terminated_workers.end();
           ++it)
         {
           (*it)->join();
@@ -388,20 +388,20 @@ namespace boost { namespace threadpool { namespace detail
       }
     }
 
-     void worker_destructed(shared_ptr<worker_type> worker) volatile
-     {
+    void worker_destructed(shared_ptr<worker_type> worker) volatile
+    {
       {
         //Lock should be local to prevent dead lock of all the worker threads
         locking_ptr<pool_type, recursive_mutex> lockedThis(*this, m_monitor);
         m_worker_count--;
         m_active_worker_count--;
-        lockedThis->m_worker_idle_or_terminated_event.notify_all();	
- 
+        lockedThis->m_worker_idle_or_terminated_event.notify_all();
+
         if(m_terminate_all_workers)
         {
           lockedThis->m_terminated_workers.push_back(worker);
         }
-       }
+      }
 
       const_cast<pool_type*>(this)->m_destruct_barrier->wait();
     }

--- a/boost/threadpool/detail/pool_core.hpp
+++ b/boost/threadpool/detail/pool_core.hpp
@@ -132,6 +132,8 @@ namespace boost { namespace threadpool { namespace detail
     mutable condition m_worker_idle_or_terminated_event;	// A worker is idle or was terminated.
     mutable condition m_task_or_terminate_workers_event;  // Task is available OR total worker count should be reduced.
 
+    scoped_ptr<barrier> m_destruct_barrier;  // Barrier used to synchronize termination of all the workers
+
   public:
     /// Constructor.
     pool_core()
@@ -296,22 +298,24 @@ namespace boost { namespace threadpool { namespace detail
     void terminate_all_workers(bool const wait) volatile
     {
       pool_type* self = const_cast<pool_type*>(this);
-      recursive_mutex::scoped_lock lock(self->m_monitor);
-
-      self->m_terminate_all_workers = true;
-
-      m_target_worker_count = 0;
-      self->m_task_or_terminate_workers_event.notify_all();
-
-      if(wait)
       {
-        while(m_active_worker_count > 0)
-        {
-          self->m_worker_idle_or_terminated_event.wait(lock);
-        }
-
-        for(typename std::vector<shared_ptr<worker_type> >::iterator it = self->m_terminated_workers.begin();
-          it != self->m_terminated_workers.end();
+          //Lock should be local to prevent dead lock of all the worker threads
+          recursive_mutex::scoped_lock lock(self->m_monitor);
+ 
+          self->m_terminate_all_workers = true;
+ 
+          self->m_destruct_barrier.reset( new barrier( m_target_worker_count + 1 ) );  
+          m_target_worker_count = 0;
+          self->m_task_or_terminate_workers_event.notify_all();
+      }
+ 
+       if(wait)
+       {
+          //Wait for termination of all the workers
+          self->m_destruct_barrier->wait();
+ 
+         for(typename std::vector<shared_ptr<worker_type> >::iterator it = self->m_terminated_workers.begin();
+           it != self->m_terminated_workers.end();
           ++it)
         {
           (*it)->join();
@@ -384,19 +388,23 @@ namespace boost { namespace threadpool { namespace detail
       }
     }
 
-    void worker_destructed(shared_ptr<worker_type> worker) volatile
-    {
-      locking_ptr<pool_type, recursive_mutex> lockedThis(*this, m_monitor);
-      m_worker_count--;
-      m_active_worker_count--;
-      lockedThis->m_worker_idle_or_terminated_event.notify_all();	
-
-      if(m_terminate_all_workers)
+     void worker_destructed(shared_ptr<worker_type> worker) volatile
+     {
       {
-        lockedThis->m_terminated_workers.push_back(worker);
-      }
-    }
+        //Lock should be local to prevent dead lock of all the worker threads
+        locking_ptr<pool_type, recursive_mutex> lockedThis(*this, m_monitor);
+        m_worker_count--;
+        m_active_worker_count--;
+        lockedThis->m_worker_idle_or_terminated_event.notify_all();	
+ 
+        if(m_terminate_all_workers)
+        {
+          lockedThis->m_terminated_workers.push_back(worker);
+        }
+       }
 
+      const_cast<pool_type*>(this)->m_destruct_barrier->wait();
+    }
 
     bool execute_task() volatile
     {

--- a/boost/threadpool/detail/worker_thread.hpp
+++ b/boost/threadpool/detail/worker_thread.hpp
@@ -59,8 +59,8 @@ namespace boost { namespace threadpool { namespace detail
     * \see function create_and_attach
     */
     worker_thread(shared_ptr<pool_type> const & pool)
-    : m_pool(pool),
-    m_start_barrier( 2 )
+      : m_pool(pool),
+      m_start_barrier(2)
     {
       assert(pool);
     }
@@ -78,7 +78,7 @@ namespace boost { namespace threadpool { namespace detail
     /*! Executes pool's tasks sequentially.
      */
     void run()
-    { 
+    {
       //self holder, used to prevent deletion of the worker
       shared_ptr<worker_thread> self(this->shared_from_this());
 
@@ -114,12 +114,12 @@ namespace boost { namespace threadpool { namespace detail
       shared_ptr<worker_thread> worker(new worker_thread(pool));
       if(worker)
       {
-	//Use the real pointer to the worker to prevent holding of the circular references
-	//to the worker in thread object
-	worker->m_thread.reset(new boost::thread(bind(&worker_thread::run, &*worker)));
+        //Use the real pointer to the worker to prevent holding of the circular references
+        //to the worker in thread object
+        worker->m_thread.reset(new boost::thread(bind(&worker_thread::run, &*worker)));
 
-	//Wait until shared pointer to this is acquired in run method
-	worker->m_start_barrier.wait();
+        //Wait until shared pointer to this is acquired in run method
+        worker->m_start_barrier.wait();
       }
     }
 

--- a/boost/threadpool/task_adaptors.hpp
+++ b/boost/threadpool/task_adaptors.hpp
@@ -135,7 +135,7 @@ namespace boost { namespace threadpool
         if(m_break_s > 0 || m_break_ns > 0)
         { // Sleep some time before first execution
           xtime xt;
-          xtime_get(&xt, TIME_UTC);
+          xtime_get(&xt, TIME_UTC_);
           xt.nsec += m_break_ns;
           xt.sec += m_break_s;
           thread::sleep(xt); 
@@ -146,7 +146,7 @@ namespace boost { namespace threadpool
           if(m_break_s > 0 || m_break_ns > 0)
           {
             xtime xt;
-            xtime_get(&xt, TIME_UTC);
+            xtime_get(&xt, TIME_UTC_);
             xt.nsec += m_break_ns;
             xt.sec += m_break_s;
             thread::sleep(xt); 


### PR DESCRIPTION
Fix for a condition where memory leaks with pthreads when resizing the thread pool. After a while, new threads cannot be created.
This uses a patch found at https://sourceforge.net/p/threadpool/bugs/4/. Full credit for this fix go to Anton Masotov, https://sourceforge.net/u/shikin/profile/ (and more recently I believe https://github.com/anton-matosov)
