### PR TITLE
boost/threadpool/detail/pool_core.hpp: Connor Smith suggests catching…

### DIFF
--- a/boost/threadpool/detail/pool_core.hpp
+++ b/boost/threadpool/detail/pool_core.hpp
@@ -350,7 +350,7 @@ namespace boost { namespace threadpool { namespace detail
             m_worker_count++;
             m_active_worker_count++;	
           }
-          catch(thread_resource_error)
+          catch(const thread_resource_error&)
           {
             return false;
           }


### PR DESCRIPTION
… by const reference to fix gcc-8's warning: catching polymorphic type ‘class boost::thread_resource_error’ by value (https://github.com/philipphenkel/threadpool/issues/5).